### PR TITLE
feat(calculatetaxamount): adding a basic function to calculate the tax amount based on tax brackets

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,43 +19,62 @@ npm install us-taxes
 ## Usage
 
 ```ts
-import { myPackage } from 'us-taxes';
+import { calculateTaxAmount } from 'us-taxes';
 
-myPackage('hello');
-//=> 'hello from my package'
+const brackets = [
+{ maxAmount: 0, rate: 0 },
+{ maxAmount: 10275, rate: 0.1 },
+{ maxAmount: 41775, rate: 0.12 },
+{ maxAmount: 89075, rate: 0.22 },
+{ maxAmount: 170050, rate: 0.24 },
+{ maxAmount: 215950, rate: 0.32 },
+{ maxAmount: 539900, rate: 0.35 },
+{ maxAmount: Infinity, rate: 0.37 },
+];
+
+
+const taxAmount = calculateTaxAmount(500, brackets);
+//=> 'taxAmount is the amount of taxes owed based on the income amount passed in'
 ```
 
 ## API
 
-### myPackage(input, options?)
+### calculateTaxAmount(amount, brackets)
 
-#### input
+#### amount
 
-Type: `string`
+Type: `number`
 
-Lorem ipsum.
+The amount of taxable income to use when calculating taxes due.
 
-#### options
+#### brackets
 
 Type: `object`
 
-##### postfix
+The tax brackets to use when calculating the amount of taxes owed for the taxable income passed in
 
-Type: `string`
-Default: `rainbows`
+##### maxAmount
 
-Lorem ipsum.
+Type: `number`
 
-[build-img]:https://github.com/ryansonshine/typescript-npm-package-template/actions/workflows/release.yml/badge.svg
-[build-url]:https://github.com/ryansonshine/typescript-npm-package-template/actions/workflows/release.yml
-[downloads-img]:https://img.shields.io/npm/dt/typescript-npm-package-template
-[downloads-url]:https://www.npmtrends.com/typescript-npm-package-template
-[npm-img]:https://img.shields.io/npm/v/typescript-npm-package-template
-[npm-url]:https://www.npmjs.com/package/typescript-npm-package-template
-[issues-img]:https://img.shields.io/github/issues/ryansonshine/typescript-npm-package-template
-[issues-url]:https://github.com/ryansonshine/typescript-npm-package-template/issues
-[codecov-img]:https://codecov.io/gh/ryansonshine/typescript-npm-package-template/branch/main/graph/badge.svg
-[codecov-url]:https://codecov.io/gh/ryansonshine/typescript-npm-package-template
+The maxAmount for the tax bracket
+
+##### rate
+
+Type: `number`
+
+The tax rate for this tax bracket
+
+[build-img]:https://github.com/jrusso1020/us-taxes/actions/workflows/release.yml/badge.svg
+[build-url]:https://github.com/jrusso1020/us-taxes/actions/workflows/release.yml
+[downloads-img]:https://img.shields.io/npm/dt/us-taxes
+[downloads-url]:https://www.npmtrends.com/us-taxes
+[npm-img]:https://img.shields.io/npm/v/us-taxes
+[npm-url]:https://www.npmjs.com/package/us-taxes
+[issues-img]:https://img.shields.io/github/issues/jrusso1020/us-taxes
+[issues-url]:https://github.com/jrusso1020/us-taxes/issues
+[codecov-img]:https://codecov.io/gh/jrusso1020/us-taxes/branch/main/graph/badge.svg
+[codecov-url]:https://codecov.io/gh/jrusso1020/us-taxes
 [semantic-release-img]:https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg
 [semantic-release-url]:https://github.com/semantic-release/semantic-release
 [commitizen-img]:https://img.shields.io/badge/commitizen-friendly-brightgreen.svg

--- a/README.md
+++ b/README.md
@@ -1,59 +1,4 @@
-# typescript-npm-package-template
-
-> Template to kickstart creating a Node.js module using TypeScript and VSCode
-
-Inspired by [node-module-boilerplate](https://github.com/sindresorhus/node-module-boilerplate)
-
-## Features
-
-- [Semantic Release](https://github.com/semantic-release/semantic-release)
-- [Issue Templates](https://github.com/ryansonshine/typescript-npm-package-template/tree/main/.github/ISSUE_TEMPLATE)
-- [GitHub Actions](https://github.com/ryansonshine/typescript-npm-package-template/tree/main/.github/workflows)
-- [Codecov](https://about.codecov.io/)
-- [VSCode Launch Configurations](https://github.com/ryansonshine/typescript-npm-package-template/blob/main/.vscode/launch.json)
-- [TypeScript](https://www.typescriptlang.org/)
-- [Husky](https://github.com/typicode/husky)
-- [Lint Staged](https://github.com/okonet/lint-staged)
-- [Commitizen](https://github.com/search?q=commitizen)
-- [Jest](https://jestjs.io/)
-- [ESLint](https://eslint.org/)
-- [Prettier](https://prettier.io/)
-
-## Getting started
-
-### Set up your repository
-
-**Click the "Use this template" button.**
-
-Alternatively, create a new directory and then run:
-
-```bash
-curl -fsSL https://github.com/ryansonshine/typescript-npm-package-template/archive/main.tar.gz | tar -xz --strip-components=1
-```
-
-Replace `FULL_NAME`, `GITHUB_USER`, and `REPO_NAME` in the script below with your own details to personalize your new package:
-
-```bash
-FULL_NAME="John Smith"
-GITHUB_USER="johnsmith"
-REPO_NAME="my-cool-package"
-sed -i.mybak "s/\([\/\"]\)(ryansonshine)/$GITHUB_USER/g; s/typescript-npm-package-template\|my-package-name/$REPO_NAME/g; s/Ryan Sonshine/$FULL_NAME/g" package.json package-lock.json README.md
-rm *.mybak
-```
-
-### Add NPM Token
-
-Add your npm token to your GitHub repository secrets as `NPM_TOKEN`.
-
-### Add Codecov integration
-
-Enable the Codecov GitHub App [here](https://github.com/apps/codecov).
-
-**Remove everything from here and above**
-
----
-
-# my-package-name
+# us-taxes
 
 [![npm package][npm-img]][npm-url]
 [![Build Status][build-img]][build-url]
@@ -68,13 +13,13 @@ Enable the Codecov GitHub App [here](https://github.com/apps/codecov).
 ## Install
 
 ```bash
-npm install my-package-name
+npm install us-taxes
 ```
 
 ## Usage
 
 ```ts
-import { myPackage } from 'my-package-name';
+import { myPackage } from 'us-taxes';
 
 myPackage('hello');
 //=> 'hello from my package'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "typescript-npm-package-template",
+  "name": "us-taxes",
   "version": "0.0.0-development",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "typescript-npm-package-template",
+      "name": "us-taxes",
       "version": "0.0.0-development",
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "typescript-npm-package-template",
-  "version": "0.0.0-development",
-  "description": "A template for creating npm packages using TypeScript and VSCode",
+  "name": "us-taxes",
+  "version": "0.0.1",
+  "description": "A node js package for calculating United States progressive income taxes",
   "main": "./lib/index.js",
   "files": [
     "lib/**/*"
@@ -19,32 +19,28 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ryansonshine/typescript-npm-package-template.git"
+    "url": "git+https://github.com/jrusso1020/us-taxes.git"
   },
   "license": "MIT",
   "author": {
-    "name": "Ryan Sonshine",
-    "email": "ryansonshine@users.noreply.github.com",
-    "url": "https://github.com/ryansonshine"
+    "name": "James Russo",
+    "email": "jdrusso1020@gmail.com",
+    "url": "https://github.com/jrusso1020"
   },
   "engines": {
     "node": ">=12.0"
   },
   "keywords": [
-    "boilerplate",
-    "template",
-    "typescript",
-    "vscode",
-    "jest",
-    "husky",
-    "commitizen",
-    "semantic-release",
-    "codecov"
+    "us",
+    "united states",
+    "taxes",
+    "progressive",
+    "income"
   ],
   "bugs": {
-    "url": "https://github.com/ryansonshine/typescript-npm-package-template/issues"
+    "url": "https://github.com/jrusso1020/us-taxes/issues"
   },
-  "homepage": "https://github.com/ryansonshine/typescript-npm-package-template#readme",
+  "homepage": "https://github.com/jrusso1020/us-taxes#readme",
   "devDependencies": {
     "@ryansonshine/commitizen": "^4.2.8",
     "@ryansonshine/cz-conventional-changelog": "^3.3.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,23 @@
-export const myPackage = (taco = ''): string => `${taco} from my package`;
+// This simple function is reponsible for calculating the of taxes owed based on the passed in amount and tax brackets
+// Params:  amount[required]: the amount of money to use for calculating taxes owed (i.e. income amount)
+//          brackets[required]: the tax brackets to use for calculating taxes
+export const calculateTaxAmount = (
+  amount: number,
+  brackets: { maxAmount: number; rate: number }[]
+) => {
+  let taxAmount = 0;
+
+  for (let index = 1; index < brackets.length; index++) {
+    if (amount > brackets[index].maxAmount) {
+      taxAmount +=
+        (brackets[index].maxAmount - brackets[index - 1].maxAmount) *
+        brackets[index].rate;
+    } else {
+      taxAmount +=
+        (amount - brackets[index - 1].maxAmount) * brackets[index].rate;
+      return taxAmount;
+    }
+  }
+
+  return taxAmount;
+};

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,13 +1,59 @@
-import { myPackage } from '../src';
+import { calculateTaxAmount } from '../src';
 
 describe('index', () => {
-  describe('myPackage', () => {
-    it('should return a string containing the message', () => {
-      const message = 'Hello';
+  describe('test calculateTaxAmount across brackets', () => {
+    const brackets = [
+      { maxAmount: 0, rate: 0 },
+      { maxAmount: 10275, rate: 0.1 },
+      { maxAmount: 41775, rate: 0.12 },
+      { maxAmount: 89075, rate: 0.22 },
+      { maxAmount: 170050, rate: 0.24 },
+      { maxAmount: 215950, rate: 0.32 },
+      { maxAmount: 539900, rate: 0.35 },
+      { maxAmount: Infinity, rate: 0.37 },
+    ];
 
-      const result = myPackage(message);
+    it('first bracket', () => {
+      expect(calculateTaxAmount(500, brackets)).toBe(500 * 0.1);
+    });
 
-      expect(result).toMatch(message);
+    it('second bracket', () => {
+      expect(calculateTaxAmount(20000, brackets)).toBe(
+        (20000 - 10275) * 0.12 + 1027.5
+      );
+    });
+
+    it('third bracket', () => {
+      expect(calculateTaxAmount(50000, brackets)).toBe(
+        (50000 - 41775) * 0.22 + 4807.5
+      );
+    });
+
+    it('fourth bracket', () => {
+      expect(calculateTaxAmount(100000, brackets)).toBe(
+        (100000 - 89075) * 0.24 + 15213.5
+      );
+    });
+
+    it('fifth bracket', () => {
+      expect(calculateTaxAmount(200000, brackets)).toBe(
+        (200000 - 170050) * 0.32 + 34647.5
+      );
+    });
+
+    it('sixth bracket', () => {
+      expect(calculateTaxAmount(500000, brackets)).toBe(
+        (500000 - 215950) * 0.35 + 49335.5
+      );
+    });
+
+    it('seventh bracket', () => {
+      expect(calculateTaxAmount(750000, brackets)).toBe(
+        (750000 - 539900) * 0.37 + 162718
+      );
+      expect(calculateTaxAmount(7500000, brackets)).toBe(
+        (7500000 - 539900) * 0.37 + 162718
+      );
     });
   });
 });


### PR DESCRIPTION
### Description of change
Adding the root function that is going to be responsible for calculating progressive income tax amount due based on the amount passed in and the tax brackets passed in
<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
  🎉 Thank you for contributing!
-->
